### PR TITLE
Remove base env update and installation as this env is not used

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,18 +17,7 @@ RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list \
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 # copy requirements
-COPY ./requirements-base.txt /
-COPY ./requirements-databricks.txt /
-COPY ./requirements-db-jlab.txt /
-COPY ./requirements-localspark.txt /
-COPY ./requirements-shared.txt /
-
-# update conda in base
-RUN conda update -n base -c defaults conda -y
-RUN /bin/bash -c 'source /root/.bashrc \
-    && conda activate base \
-    && pip install -r /requirements-shared.txt \
-    && pip install -r /requirements-base.txt'
+COPY ./requirements-*.txt /
 
 # create environment localspark
 RUN conda create -n localspark python=3.7.3 -y


### PR DESCRIPTION
To make docker build lighter, this PR removes unnecessary base env update and library installation. 

This addresses docker build error below as pip install doesn't run in base env anymore. 

```
Step 10/23 : RUN /bin/bash -c 'source /root/.bashrc     && conda activate base
   && pip install -r /requirements-shared.txt     && pip install -r /requirement
s-base.txt'
 ---> Running in 1b15189f1bd0
/bin/bash: pip: command not found
ERROR: Service 'workspace' failed to build: The command '/bin/sh -c /bin/bash -c
 'source /root/.bashrc     && conda activate base     && pip install -r /require
ments-shared.txt     && pip install -r /requirements-base.txt'' returned a non-z
ero code: 127
```