### PR TITLE
Dev container improvement by keeping only 1 linter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,30 +5,37 @@
   "context": "..",
   "workspaceFolder": "/workspace",
   "settings": {
-    "python.formatting.blackArgs": [ "--line-length=79" ],
+    "python.formatting.blackArgs": [
+      "--line-length=79"
+    ],
     "python.formatting.provider": "black",
     "python.linting.banditEnabled": true,
     "python.linting.enabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,
-    "python.linting.pycodestyleEnabled": true,
     "python.linting.pydocstyleEnabled": true,
-    "python.linting.pylintEnabled": true,
     "python.pythonPath": "/opt/conda/envs/localspark/bin/python",
-    "python.sortImports.args": [ "-m 3", "-tc", "-sp ${workspaceFolder}/configs/isort.cfg" ],
+    "python.sortImports.args": [
+      "-m 3",
+      "-tc",
+      "-sp ${workspaceFolder}/configs/isort.cfg"
+    ],
     "python.sortImports.path": "isort",
     "terminal.integrated.inheritEnv": false,
     "terminal.integrated.shell.linux": "/bin/bash",
     "[python]": {
       "editor.formatOnSave": true,
-      "editor.codeActionsOnSave": { "source.organizeImports.python": true },
+      "editor.codeActionsOnSave": {
+        "source.organizeImports.python": true
+      },
       "files.trimTrailingWhitespace": true
     }
   },
   "extensions": [
     "ms-python.python",
     "paiqo.databricks-vscode",
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "njpwerner.autodocstring"
   ],
   "postAttachCommand": "mkdir -p /root/.ssh && touch /root/.ssh/config",
 }

--- a/.devcontainer/requirements-shared.txt
+++ b/.devcontainer/requirements-shared.txt
@@ -9,6 +9,4 @@ black
 flake8
 isort
 mypy
-pycodestyle
 pydocstyle
-pylint

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb
+
+# For git line ending issues
+# https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
- Kept only flake8 as linter for python
- Added vscode extension for python docstring
- Modified gitattributes to prevent line encoding issue between local and container